### PR TITLE
[feature#19] 메세지 저장 및 보드 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/FirstSoriApplication.java
+++ b/src/main/java/com/goormthon/backend/firstsori/FirstSoriApplication.java
@@ -3,8 +3,10 @@ package com.goormthon.backend.firstsori;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class FirstSoriApplication {
 

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/BoardInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/BoardInfoResponse.java
@@ -1,0 +1,18 @@
+package com.goormthon.backend.firstsori.domain.board.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+// 보드 정보 응답 DTO
+@Builder
+@Schema(description = "보드 정보 및 소유자 프로필 응답")
+public record BoardInfoResponse(
+        @Schema(description = "보드 소유자의 닉네임")
+        String name,
+
+        @Schema(description = "보드 소유자의 프로필 이미지 URL")
+        String profileImage,
+
+        @Schema(description = "보드에 등록된 메시지 수")
+        Integer messageCount) {
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/mapper/BoardMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/mapper/BoardMapper.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.firstsori.domain.board.application.mapper;
+
+import com.goormthon.backend.firstsori.domain.board.application.dto.BoardInfoResponse;
+
+public class BoardMapper {
+
+    public static BoardInfoResponse toBoardInfoResponse(String name,String profileImage,Integer messageCount) {
+        return BoardInfoResponse.builder()
+                .name(name)
+                .profileImage(profileImage)
+                .messageCount(messageCount)
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
@@ -1,0 +1,11 @@
+package com.goormthon.backend.firstsori.domain.board.application.usecase;
+
+import com.goormthon.backend.firstsori.domain.board.application.dto.BoardInfoResponse;
+
+import java.util.UUID;
+
+public interface BoardUseCase {
+
+    BoardInfoResponse getBoardInfo(UUID userId);
+
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
@@ -1,0 +1,37 @@
+package com.goormthon.backend.firstsori.domain.board.application.usecase;
+
+import com.goormthon.backend.firstsori.domain.board.application.dto.BoardInfoResponse;
+import com.goormthon.backend.firstsori.domain.board.application.mapper.BoardMapper;
+import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
+import com.goormthon.backend.firstsori.domain.message.domain.service.GetMessageService;
+import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
+import com.goormthon.backend.firstsori.domain.user.domain.service.GetUserService;
+import com.goormthon.backend.firstsori.global.common.exception.ErrorCode;
+import com.goormthon.backend.firstsori.global.common.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardUseCaseImpl implements BoardUseCase {
+
+    private final GetUserService getUserService;
+
+    @Transactional(readOnly = true)
+    @Override
+    public BoardInfoResponse getBoardInfo(UUID userId) {
+        User user = Optional.ofNullable(getUserService.validateUserExists(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+       // 보드랑 연결후에 작동 (혜연님 코드)
+        Board board = Optional.ofNullable(user.getBoard())
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+        return BoardMapper.toBoardInfoResponse(user.getName(), user.getProfileImage(), board.getMessageCount());
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
@@ -29,4 +29,22 @@ import java.util.UUID;
 
      @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
      private List<Message> messages = new ArrayList<>();
+
+    @Column(nullable = false)
+    private int messageCount = 0;
+
+    @Column(nullable = false)
+    private String sharedId;
+
+    public void incrementMessageCount(int redisCount) {
+         this.messageCount += redisCount;
+     }
+
+    public void decrementMessageCount() {
+         if (this.messageCount > 0) {
+             this.messageCount--;
+         }
+     }
+
+
  }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/repository/BoardRepository.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/repository/BoardRepository.java
@@ -4,6 +4,10 @@ import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    Optional<Board> findBySharedId(String sharedId);
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/service/GetBoardService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/service/GetBoardService.java
@@ -1,0 +1,24 @@
+package com.goormthon.backend.firstsori.domain.board.domain.service;
+
+import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
+import com.goormthon.backend.firstsori.domain.board.domain.repository.BoardRepository;
+import com.goormthon.backend.firstsori.global.common.exception.ErrorCode;
+import com.goormthon.backend.firstsori.global.common.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class GetBoardService {
+
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public Board getBoardBySharedId(String sharedId) {
+        return boardRepository.findBySharedId(sharedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MESSAGE_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
@@ -1,15 +1,18 @@
 package com.goormthon.backend.firstsori.domain.board.presentation;
 
+import com.goormthon.backend.firstsori.domain.board.application.dto.BoardInfoResponse;
+import com.goormthon.backend.firstsori.domain.board.application.usecase.BoardUseCase;
 import com.goormthon.backend.firstsori.domain.board.presentation.spec.BoardControllerSpec;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.domain.message.application.usecase.MessageUseCase;
 import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
+import com.goormthon.backend.firstsori.global.auth.oauth2.domain.PrincipalDetails;
 import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -20,6 +23,7 @@ import java.util.UUID;
 public class BoardController implements BoardControllerSpec {
 
     private final MessageUseCase messageUseCase;
+    private final BoardUseCase boardUseCase;
 
     // 개별 메세지 조회
     @GetMapping("/{messageId}")
@@ -31,10 +35,18 @@ public class BoardController implements BoardControllerSpec {
     // 전체 메세지 리스트 정보 조회
     @GetMapping
     public ApiResponse<PageResponse<MessageListResponse>> getMessages(
-            @RequestParam UUID userId,
+            @AuthenticationPrincipal PrincipalDetails user,
             Pageable pageable) {
-        PageResponse<MessageListResponse> messageListResponses = messageUseCase.getMessages(userId, pageable);
+        PageResponse<MessageListResponse> messageListResponses = messageUseCase.getMessages(user.getId(), pageable);
         return ApiResponse.ok(messageListResponses);
+    }
+
+
+    // 보드 정보 반환
+    @GetMapping("/info")
+    public ApiResponse<BoardInfoResponse> getBoardInfo(@AuthenticationPrincipal PrincipalDetails user) {
+        BoardInfoResponse boardInfo=boardUseCase.getBoardInfo(user.getId());
+        return ApiResponse.ok(boardInfo);
     }
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
@@ -1,16 +1,19 @@
 package com.goormthon.backend.firstsori.domain.board.presentation.spec;
 
+import com.goormthon.backend.firstsori.domain.board.application.dto.BoardInfoResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
+import com.goormthon.backend.firstsori.global.auth.oauth2.domain.PrincipalDetails;
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -51,17 +54,27 @@ public interface BoardControllerSpec {
     })
     @GetMapping
     com.goormthon.backend.firstsori.global.common.response.ApiResponse<PageResponse<MessageListResponse>> getMessages(
-            @Parameter(
-                    description = "메세지를 조회할 사용자 ID",
-                    example = "fd1c199e-ae84-4cbd-9baa-e94da3d553d0"
-            )
-            @RequestParam UUID userId,
 
+            @AuthenticationPrincipal PrincipalDetails user,
             @Parameter(
                     description = "페이징 정보",
-                    example = "{ \"page\": 0, \"size\": 10, \"sort\": [\"createdDate,desc\"] }"
+                    example = "{ \"page\": 0, \"size\": 10, \"sort\": [\"desc\"] }"
             )
             Pageable pageable
     );
+
+    @Operation(
+            summary = "보드 정보 반환",
+            description = "인증된 사용자의 보드 정보(닉네임, 프로필 사진, 총 메시지 수 등)를 반환합니다. 토큰이 필요합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "보드 정보 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (토큰 부재 또는 유효하지 않은 토큰)"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping("/info")
+    com.goormthon.backend.firstsori.global.common.response.ApiResponse<BoardInfoResponse> getBoardInfo(
+            @AuthenticationPrincipal PrincipalDetails user
+            );
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/dto/request/SaveMessageRequest.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/dto/request/SaveMessageRequest.java
@@ -1,0 +1,44 @@
+package com.goormthon.backend.firstsori.domain.message.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "메시지 저장 요청 DTO")
+public record SaveMessageRequest(
+        @Schema(description = "Board의 shared ID", example = "abcd1234")
+        @NotBlank
+        String sharedId,
+
+        @Schema(description = "닉네임", example = "홍길동", maxLength = 30)
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 30, message = "닉네임은 30자 이하로 입력해주세요.")
+        String senderName,
+
+        @Schema(description = "내용", example = "새해 복 많이 많으세요:)", maxLength = 500)
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = 500, message = "내용은 500자 이하로 입력해주세요.")
+        String content,
+
+        @Schema(description = "노래 제목", example = "Shape of You", maxLength = 100)
+        @NotBlank(message = "노래 제목은 필수입니다.")
+        @Size(max = 100, message = "노래 제목은 100자 이하로 입력해주세요.")
+        String songTitle,
+
+        @Schema(description = "아티스트 이름", example = "Ed Sheeran", maxLength = 50)
+        @NotBlank(message = "아티스트는 필수입니다.")
+        @Size(max = 50, message = "아티스트 이름은 50자 이하로 입력해주세요.")
+        String artist,
+
+        @Schema(description = "앨범 이미지 URL", example = "https://albums.example.com/album1.jpg")
+        @NotNull(message = "앨범 이미지 URL은 필수입니다.")
+        String albumImageUrl,
+
+        @Schema(description = "노래 URL", example = "https://songs.example.com/song1.mp3")
+        @NotNull(message = "노래 URL은 필수입니다.")
+        String songUrl
+) {
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/dto/response/MessageListResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/dto/response/MessageListResponse.java
@@ -1,15 +1,24 @@
 package com.goormthon.backend.firstsori.domain.message.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.util.List;
 import java.util.UUID;
 
+// 메시지 목록 응답 DTO
 @Builder
+@Schema(description = "보드에 있는 메시지 목록 응답")
 public record MessageListResponse(
+        @Schema(description = "메시지 고유 ID")
         UUID messageId,
+
+        @Schema(description = "메시지 발신자 닉네임")
         String sender,
+
+        @Schema(description = "커버 이미지 URL")
         String coverImageUrl,
+
+        @Schema(description = "메시지 읽음 여부")
         boolean read
 ) {
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/dto/response/MessageResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/dto/response/MessageResponse.java
@@ -1,19 +1,36 @@
 package com.goormthon.backend.firstsori.domain.message.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.UUID;
 
+// 단일 메시지 상세 정보 응답 DTO
 @Builder
+@Schema(description = "메시지 상세 정보 응답")
 public record MessageResponse(
-    UUID messageId,
-    String senderName,
-    String content,
+        @Schema(description = "메시지 고유 ID")
+        UUID messageId,
 
-    UUID songId,
-    String songName,
-    String artist,
-    String coverImageUrl,
-    String songUrl
+        @Schema(description = "메시지 발신자 닉네임")
+        String senderName,
+
+        @Schema(description = "메시지 내용")
+        String content,
+
+        @Schema(description = "음악 고유 ID")
+        UUID songId,
+
+        @Schema(description = "음악 제목")
+        String songName,
+
+        @Schema(description = "아티스트 이름")
+        String artist,
+
+        @Schema(description = "커버 이미지 URL")
+        String coverImageUrl,
+
+        @Schema(description = "음악 URL")
+        String songUrl
 ) {
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/mapper/MessageMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/mapper/MessageMapper.java
@@ -1,8 +1,11 @@
 package com.goormthon.backend.firstsori.domain.message.application.mapper;
 
+import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
+import com.goormthon.backend.firstsori.domain.message.application.dto.request.SaveMessageRequest;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.domain.message.domain.entity.Message;
+import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -64,5 +67,19 @@ public class MessageMapper {
                 .build();
     }
 
+    public static Message toMessageEntity(SaveMessageRequest request,Board board,Music music)
+    {
+        if (request == null) {
+            return null;
+        }
+        return Message.builder()
+                .board(board)
+                .senderName(request.senderName())
+                .content(request.content())
+                .music(music)
+                .read(false)
+                .customImageUrl(null)
+                .build();
+    }
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCase.java
@@ -1,9 +1,9 @@
 package com.goormthon.backend.firstsori.domain.message.application.usecase;
 
+import com.goormthon.backend.firstsori.domain.message.application.dto.request.SaveMessageRequest;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
@@ -13,5 +13,7 @@ public interface MessageUseCase {
     MessageResponse getMessage(UUID messageId);
 
     PageResponse<MessageListResponse> getMessages(UUID userId, Pageable pageable); // 페이지 네이션 필요?
+
+    void createMessage(SaveMessageRequest request);
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCaseImpl.java
@@ -1,15 +1,18 @@
 package com.goormthon.backend.firstsori.domain.message.application.usecase;
 
 import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
-import com.goormthon.backend.firstsori.domain.board.domain.repository.BoardRepository;
+import com.goormthon.backend.firstsori.domain.board.domain.service.GetBoardService;
+import com.goormthon.backend.firstsori.domain.message.application.dto.request.SaveMessageRequest;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.domain.message.application.mapper.MessageMapper;
 import com.goormthon.backend.firstsori.domain.message.domain.entity.Message;
-import com.goormthon.backend.firstsori.domain.message.domain.repository.MessageRepository;
 import com.goormthon.backend.firstsori.domain.message.domain.service.GetMessageService;
+import com.goormthon.backend.firstsori.domain.message.domain.service.SaveMessageService;
+import com.goormthon.backend.firstsori.domain.music.application.mapper.MusicMapper;
+import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
+import com.goormthon.backend.firstsori.domain.music.domain.service.SaveMusicService;
 import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
-import com.goormthon.backend.firstsori.domain.user.domain.repository.UserRepository;
 import com.goormthon.backend.firstsori.domain.user.domain.service.GetUserService;
 import com.goormthon.backend.firstsori.global.common.exception.ErrorCode;
 import com.goormthon.backend.firstsori.global.common.response.CustomException;
@@ -18,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +35,10 @@ public class MessageUseCaseImpl implements MessageUseCase {
 
     private final GetMessageService getMessageService;
     private final GetUserService getUserService;
-
+    private final SaveMessageService saveMessageService;
+    private final GetBoardService getBoardService;
+    private final SaveMusicService saveMusicService;
+    private final RedisTemplate<String, String> redisTemplate; // RedisTemplate 주입
 
     @Override
     public MessageResponse getMessage(UUID messageId) {
@@ -51,4 +58,24 @@ public class MessageUseCaseImpl implements MessageUseCase {
         Page<Message> messages = getMessageService.getMessageList(userId,pageable);
         return MessageMapper.toMessageListResponse(messages);
     }
+
+    @Override
+    public void createMessage(SaveMessageRequest request) {
+
+        Board board = Optional.ofNullable(getBoardService.getBoardBySharedId(request.sharedId()))
+                    .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+        // 음악 정보 엔티티 생성
+        Music music = MusicMapper.toMusicEntity(request.songTitle(), request.artist(), request.albumImageUrl(), request.songUrl());
+        saveMusicService.saveMusic(music);
+
+        // 메시지 엔티티 생성
+        Message message = MessageMapper.toMessageEntity(request, board, music);
+        saveMessageService.saveMessage(message);
+
+        // 보드의 메시지 카운트를 Redis에서 증가
+        String redisKey = "board:messageCount:" + board.getBoardId().toString();
+        redisTemplate.opsForValue().increment(redisKey);
+    }
+
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/domain/entity/Message.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/domain/entity/Message.java
@@ -35,7 +35,7 @@ public class Message extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Boolean read = false;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/domain/service/GetMessageService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/domain/service/GetMessageService.java
@@ -10,17 +10,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class GetMessageService {
 
     private final MessageRepository messageRepository;
 
-    @Transactional
+
     public Message getMessage(UUID messageId) {
         messageRepository.markReadIfUnread(messageId);
         // 수정됐든 안됐든 메시지 조회 (1번 쿼리)
@@ -30,7 +29,6 @@ public class GetMessageService {
 
 
     public Page<Message> getMessageList(UUID userId, Pageable pageable) {
-
         Page<Message> messages = messageRepository.findAllByUserId(userId, pageable);
         if (messages.isEmpty()) {
             throw new CustomException(ErrorCode.MESSAGE_NOT_FOUND);

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/domain/service/SaveMessageService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/domain/service/SaveMessageService.java
@@ -1,0 +1,19 @@
+package com.goormthon.backend.firstsori.domain.message.domain.service;
+
+import com.goormthon.backend.firstsori.domain.message.domain.entity.Message;
+import com.goormthon.backend.firstsori.domain.message.domain.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SaveMessageService {
+
+    private final MessageRepository messageRepository;
+
+    public void saveMessage(Message message) {
+        messageRepository.save(message);
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/presentation/MessageController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/presentation/MessageController.java
@@ -1,0 +1,26 @@
+package com.goormthon.backend.firstsori.domain.message.presentation;
+
+import com.goormthon.backend.firstsori.domain.message.application.dto.request.SaveMessageRequest;
+import com.goormthon.backend.firstsori.domain.message.application.usecase.MessageUseCase;
+import com.goormthon.backend.firstsori.domain.message.presentation.spec.MessageControllerSpec;
+import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/v1/message")
+@RequiredArgsConstructor
+public class MessageController implements MessageControllerSpec {
+
+    private final MessageUseCase messageUseCase;
+
+    @PostMapping
+    public ApiResponse<String> sendMessage(
+            @Valid @RequestBody SaveMessageRequest request) {
+        messageUseCase.createMessage(request);
+        return ApiResponse.ok("메세지 발행 성공");
+
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/presentation/spec/MessageControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/presentation/spec/MessageControllerSpec.java
@@ -1,0 +1,28 @@
+package com.goormthon.backend.firstsori.domain.message.presentation.spec;
+
+import com.goormthon.backend.firstsori.domain.message.application.dto.request.SaveMessageRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Message API", description = "메세지 관련 API")
+public interface MessageControllerSpec {
+
+    @Operation(
+            summary = "메시지 생성",
+            description = "익명 사용자를 포함한 모든 사용자가 보드에 메시지를 게시합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "메시지 발행 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 데이터가 유효하지 않거나, 필수 정보가 누락되었습니다."),
+            @ApiResponse(responseCode = "404", description = "요청된 보드 ID를 찾을 수 없습니다.")
+    })
+    @PostMapping
+    com.goormthon.backend.firstsori.global.common.response.ApiResponse<String> sendMessage(
+            @RequestBody @Valid SaveMessageRequest request
+    );
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
@@ -1,0 +1,15 @@
+package com.goormthon.backend.firstsori.domain.music.application.mapper;
+
+import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
+
+public class MusicMapper {
+
+    public static Music toMusicEntity(String songTitle, String artist, String albumImageUrl, String songUrl) {
+        return Music.builder()
+                .songName(songTitle)
+                .artist(artist)
+                .albumImageUrl(albumImageUrl)
+                .songUrl(songUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/SaveMusicService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/SaveMusicService.java
@@ -1,0 +1,19 @@
+package com.goormthon.backend.firstsori.domain.music.domain.service;
+
+import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
+import com.goormthon.backend.firstsori.domain.music.domain.repository.MusicRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SaveMusicService {
+
+    private final MusicRepository musicRepository;
+
+    public void saveMusic(Music music) {
+        musicRepository.save(music);
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/user/domain/entity/enums/Role.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/user/domain/entity/enums/Role.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
     USER("USER"),
+    ANONYMOUS("ANONYMOUS"),
     ADMIN("ADMIN");
 
     private final String role;

--- a/src/main/java/com/goormthon/backend/firstsori/global/auth/jwt/filter/RequestMatcherHolder.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/auth/jwt/filter/RequestMatcherHolder.java
@@ -34,6 +34,9 @@ public class RequestMatcherHolder {
             new RequestInfo(POST, "/api/v1/auth/reissue", null),
             new RequestInfo(POST, "/api/v1/auth/logout", Role.USER),
 
+            // 메세지 전송
+            new RequestInfo(POST, "/api/v1/message", null),
+
             // static resources
             new RequestInfo(GET, "/docs/**", null),
             new RequestInfo(GET, "/*.ico", null),

--- a/src/main/java/com/goormthon/backend/firstsori/global/common/scheduler/BoardCountSyncScheduler.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/common/scheduler/BoardCountSyncScheduler.java
@@ -1,0 +1,50 @@
+package com.goormthon.backend.firstsori.global.common.scheduler;
+
+import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
+import com.goormthon.backend.firstsori.domain.board.domain.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BoardCountSyncScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final BoardRepository boardRepository;
+
+    /**
+     * Redis의 보드 메시지 카운트와 DB를 동기화하는 스케줄러 메서드
+     * 30초마다 실행됩니다.
+     */
+    @Scheduled(fixedDelay = 30000)
+    public void syncBoardMessageCounts() {
+//        log.info("[스케줄러 실행] Board 메시지 카운트 동기화 시작"); // 시작 로그
+
+        List<Board> allBoards = boardRepository.findAll();
+
+        for (Board board : allBoards) {
+            String redisKey = "board:messageCount:" + board.getBoardId().toString();
+            String countString = redisTemplate.opsForValue().get(redisKey);        // Redis에서 현재 카운트 값을 가져옴
+
+            if (countString != null) {
+                Integer redisCount = Integer.parseInt(countString);
+
+                // DB의 기존 카운트에 Redis 카운트 값을 더함
+                board.incrementMessageCount(redisCount);
+                boardRepository.save(board);
+
+                // Redis 카운트 초기화
+                redisTemplate.delete(redisKey); //  redisTemplate.opsForValue().set(redisKey, "0");
+//                log.info("Board ID: {}에 {}개의 메시지 카운트 동기화 완료.", board.getBoardId(), redisCount);
+            }
+        }
+//        log.info("[스케줄러 종료] Board 메시지 카운트 동기화 완료.");
+
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용  
 - 비회원이 보드 ID를 통해 메시지를 보낼 수 있도록 `SaveMessageRequest`에 `sharedId` 필드를 추가
 - 5분마다 Redis에 누적된 `messageCount` 값을 DB에 일괄 반영하는 스케줄러 (`BoardCountSyncScheduler`) 추가
- Message` 엔티티의 `read` 필드에 `false` 기본값을 추가하여 null 제약조건 오류 해결
-  swagger 애노테이션 추가


## 🔍 참고 사항  
- application.yml secret에 업데이트 -> local, prod 분리

## 🖼️ 스크린샷  
### board info 조회


- messageCount는 redis에 저장했다가 30초 간격으로 update(시간은 조절할 예정)
<img width="1033" height="326" alt="image (19)" src="https://github.com/user-attachments/assets/a164c624-af93-4a47-8b38-6bd7742190c1" />

### 메세지 발행
<img width="1195" height="776" alt="image (20)" src="https://github.com/user-attachments/assets/9d050e24-fa94-4859-9d98-461fde901420" />


- board에 sharedId가 어떤 형식으로 추가되는지 확인후 수정할 예정(지금은 String), URL은 일단 String으로 설정(URL 타입도 있긴함)
<img width="1159" height="229" alt="image (22)" src="https://github.com/user-attachments/assets/1bc50713-c36c-4c91-990c-b50b25a2c09f" />

## 🔗 관련 이슈  
#19 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
