### PR TITLE
[Feature/#13] 곡 검색 API, Redis 캐싱 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'  // WebClient 포함
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/GetSearchResultResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/GetSearchResultResponse.java
@@ -1,8 +1,14 @@
 package com.goormthon.backend.firstsori.domain.music.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+// 음악 검색 결과 DTO
+@Schema(name = "[GET] 음악 검색 response",
+        description = "음악 검색 결과 응답")
 public record GetSearchResultResponse(
+
+        @Schema(description = "검색된 곡 정보 목록")
         List<SongData> searchResult
 ) {
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/GetSearchResultResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/GetSearchResultResponse.java
@@ -1,0 +1,8 @@
+package com.goormthon.backend.firstsori.domain.music.application.dto.response;
+
+import java.util.List;
+
+public record GetSearchResultResponse(
+        List<SongData> searchResult
+) {
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/SongData.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/SongData.java
@@ -1,11 +1,27 @@
 package com.goormthon.backend.firstsori.domain.music.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 음악 메타데이터 DTO
+@Schema(description = "음악 메타데이터 응답")
 public record SongData(
+
+        @Schema(description = "곡 고유 ID")
         String songId,
+
+        @Schema(description = "곡 제목")
         String songTitle,
+
+        @Schema(description = "아티스트명 (여러 명일 경우 콤마 구분)")
         String artist,
+
+        @Schema(description = "커버 이미지 URL (앨범 이미지)")
         String coverImage,
+
+        @Schema(description = "곡 스트리밍 URL (Spotify 등 외부 링크)")
         String streamingUrl,
+
+        @Schema(description = "미리 듣기 URL (30초 미리듣기 등)")
         String prestreamingUrl
 ) {
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/SongData.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/SongData.java
@@ -1,0 +1,11 @@
+package com.goormthon.backend.firstsori.domain.music.application.dto.response;
+
+public record SongData(
+        String songId,
+        String songTitle,
+        String artist,
+        String coverImage,
+        String streamingUrl,
+        String prestreamingUrl
+) {
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/SongDataMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/SongDataMapper.java
@@ -1,0 +1,22 @@
+package com.goormthon.backend.firstsori.domain.music.application.mapper;
+
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.SongData;
+import com.goormthon.backend.firstsori.global.spotify.application.dto.response.SpotifySearchApiResponse;
+
+import java.util.stream.Collectors;
+
+public class SongDataMapper {
+
+    public static SongData toSongData(SpotifySearchApiResponse.Item item) {
+        return new SongData(
+                item.getId(),
+                item.getName(),
+                item.getArtists().stream()
+                        .map(SpotifySearchApiResponse.Artist::getName)
+                        .collect(Collectors.joining(", ")),
+                item.getAlbum().getImages().get(0).getUrl(),
+                item.getExternal_urls().getSpotify(),
+                item.getPreview_url()
+        );
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCase.java
@@ -1,0 +1,9 @@
+package com.goormthon.backend.firstsori.domain.music.application.usecase;
+
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+
+public interface MusicUseCase {
+
+    GetSearchResultResponse getSearchResult(String keyword);
+
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCaseImpl.java
@@ -1,0 +1,22 @@
+package com.goormthon.backend.firstsori.domain.music.application.usecase;
+
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.domain.music.domain.service.GetMusicSearchResultService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MusicUseCaseImpl implements MusicUseCase {
+
+    private final GetMusicSearchResultService getMusicSearchResultService;
+
+    @Override
+    public GetSearchResultResponse getSearchResult(String keyword) {
+        return new GetSearchResultResponse(getMusicSearchResultService.getSearchResult(keyword));
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/MusicService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/MusicService.java
@@ -1,0 +1,148 @@
+package com.goormthon.backend.firstsori.domain.music.domain.service;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.SongData;
+import com.goormthon.backend.firstsori.global.common.response.CustomException;
+import com.goormthon.backend.firstsori.global.spotify.application.dto.response.SpotifySearchApiResponse;
+import com.goormthon.backend.firstsori.global.spotify.domain.client.SpotifyApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.goormthon.backend.firstsori.domain.music.domain.util.PrefixUtil.*;
+import static com.goormthon.backend.firstsori.global.common.exception.ErrorCode.REDIS_SERIALIZATION_ERROR;
+import static com.goormthon.backend.firstsori.global.common.exception.ErrorCode.SPOTIFY_API_CALL_FAILED;
+
+@Service
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class MusicService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final SpotifyApiClient spotifyApiClient;
+
+    private static final int POPULAR_THRESHOLD = 10;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    /*    private static final String PREFIX = "spotify:search:";
+        private static final String SEARCH_PREFIX = "spotify:search:";
+        private static final String TRACK_PREFIX = "spotify:track:";
+        private static final String COUNT_PREFIX = "spotify:search:count:";*/
+
+    /**
+     *  키워드 검색횟수 TTL (countKey) :  7일
+     *  키워드 검색결과  TTL (searchKey) : 기본 1시간 캐싱
+     *  10회 이상 검색된 키워드의 검색결과 TTL (trackKey) : 24시간
+    */
+    public List<SongData> getSearchResult(String keyword) {
+        String searchKey = SEARCH_PREFIX + keyword.toLowerCase();
+        String countKey = COUNT_PREFIX + keyword.toLowerCase();
+
+        // 1. 캐시 조회
+        List<SongData> cachedResult = getCachedSearchResult(searchKey, countKey);
+        if (cachedResult != null) return cachedResult;
+
+        // 2. Spotify API 호출
+        SpotifySearchApiResponse response = getSpotifySearchApiResponse(keyword);
+
+        List<SongData> musicList = response.getTracks().getItems().stream()
+                .map(mapToSongData())
+                .collect(Collectors.toList());
+
+        // 3. 검색 횟수 증가
+        Long count = incrementSearchCount(countKey);
+
+        // 4. 검색 결과 캐싱 (TTL은 해당 키워드 최근 검색 횟수에 따라 다르게 설정)
+        cacheSearchResult(count, searchKey, musicList);
+
+        return musicList;
+    }
+
+    // 검색 결과 캐시 조회
+    private List<SongData> getCachedSearchResult(String searchKey, String countKey) {
+        String cached = redisTemplate.opsForValue().get(searchKey);
+        if (cached != null) {
+            incrementSearchCount(countKey);
+            try {
+                return objectMapper.readValue(cached, new TypeReference<List<SongData>>() {});
+            } catch (JsonProcessingException e) {
+                throw new CustomException(REDIS_SERIALIZATION_ERROR);
+            }
+        }
+        return null;
+    }
+
+    // Response 내 Item을 SongData로 변환
+    private Function<SpotifySearchApiResponse.Item, SongData> mapToSongData() {
+        return item -> {
+            SongData songMetaData = new SongData(
+                    item.getId(),
+                    item.getName(),
+                    item.getArtists().stream()
+                            .map(SpotifySearchApiResponse.Artist::getName)
+                            .collect(Collectors.joining(", ")),
+                    item.getAlbum().getImages().get(0).getUrl(),
+                    item.getExternal_urls().getSpotify(),
+                    item.getPreview_url()
+            );
+
+            // 곡 단위 캐싱
+            cacheTrack(item, songMetaData);
+            return songMetaData;
+        };
+    }
+
+    // 곡 단위 캐싱
+    private void cacheTrack(SpotifySearchApiResponse.Item item, SongData songMetaData) {
+        String trackKey = TRACK_PREFIX + item.getId();
+        try {
+            redisTemplate.opsForValue().set(trackKey,
+                    objectMapper.writeValueAsString(songMetaData),
+                    Duration.ofHours(24)); // 24h TTL
+        } catch (JsonProcessingException e) {
+            throw new CustomException(REDIS_SERIALIZATION_ERROR);
+        }
+    }
+
+    // 검색 횟수 증가
+    private Long incrementSearchCount(String countKey) {
+        Long count = redisTemplate.opsForValue().increment(countKey);
+        redisTemplate.expire(countKey, Duration.ofDays(7));
+        return count;
+    }
+
+    // 검색 결과 캐싱
+    private void cacheSearchResult(Long count, String searchKey, List<SongData> musicList) {
+        int ttl = (count != null && count >= POPULAR_THRESHOLD) ? 86400 : 3600;
+        try {
+            redisTemplate.opsForValue().set(searchKey,
+                    objectMapper.writeValueAsString(musicList),
+                    Duration.ofSeconds(ttl));
+        } catch (JsonProcessingException e) {
+            throw new CustomException(REDIS_SERIALIZATION_ERROR);
+        }
+    }
+
+    // spotify api 호출
+    private SpotifySearchApiResponse getSpotifySearchApiResponse(String keyword) {
+        SpotifySearchApiResponse response;
+        try {
+            response = spotifyApiClient.searchMusicRaw(keyword);
+            log.error(response.toString());
+        } catch (Exception e) {
+            throw new CustomException(SPOTIFY_API_CALL_FAILED);
+        }
+        return response;
+    }
+
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/util/PrefixUtil.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/util/PrefixUtil.java
@@ -1,0 +1,11 @@
+package com.goormthon.backend.firstsori.domain.music.domain.util;
+
+public class PrefixUtil {
+
+    // Redis prefix
+    public static final String PREFIX = "spotify:search:";
+    public static final String SEARCH_PREFIX = "spotify:search:";
+    public static final String TRACK_PREFIX = "spotify:track:";
+    public static final String COUNT_PREFIX = "spotify:search:count:";
+
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/MusicController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/MusicController.java
@@ -2,9 +2,8 @@ package com.goormthon.backend.firstsori.domain.music.presentation;
 
 import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
 import com.goormthon.backend.firstsori.domain.music.application.usecase.MusicUseCase;
+import com.goormthon.backend.firstsori.domain.music.presentation.spec.MusicControllerSpec;
 import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/music")
 @RestController
 @RequiredArgsConstructor
-public class MusicController {
+public class MusicController implements MusicControllerSpec {
 
     private final MusicUseCase musicUseCase;
 

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/MusicController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/MusicController.java
@@ -1,0 +1,30 @@
+package com.goormthon.backend.firstsori.domain.music.presentation;
+
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.domain.music.application.usecase.MusicUseCase;
+import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping("/api/v1/music")
+@RestController
+@RequiredArgsConstructor
+public class MusicController {
+
+    private final MusicUseCase musicUseCase;
+
+    // 키워드로 음악 검색
+    @GetMapping("/search")
+    public ApiResponse<GetSearchResultResponse> getSearchResult(
+            @RequestParam String keyword) {
+        GetSearchResultResponse response = musicUseCase.getSearchResult(keyword);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/spec/MusicControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/spec/MusicControllerSpec.java
@@ -1,0 +1,19 @@
+package com.goormthon.backend.firstsori.domain.music.presentation.spec;
+
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "음악 관련 API", description = "음악 검색 기능을 제공하는 API 입니다.")
+public interface MusicControllerSpec {
+
+    @Operation(
+            summary = "음악 검색 API",
+            description = "키워드를 바탕으로 음악을 검색하고 결과를 반환합니다."
+    )
+    ApiResponse<GetSearchResultResponse> getSearchResult(
+            @RequestParam String keyword);
+}
+

--- a/src/main/java/com/goormthon/backend/firstsori/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/common/exception/ErrorCode.java
@@ -72,7 +72,11 @@ public enum ErrorCode {
         // ========================
         // 500 Internal Server Error
         // ========================
-        INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+        INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+        SPOTIFY_API_CALL_FAILED(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "Spotify API 호출이 실패했습니다."),
+        REDIS_SERIALIZATION_ERROR(500_002, HttpStatus.INTERNAL_SERVER_ERROR, "Redis 캐싱 직렬화를 실패했습니다."),
+        REDIS_JSON_PROCESSING_ERROR(500_003, HttpStatus.INTERNAL_SERVER_ERROR, "Redis JSON 처리에 실패했습니다.");
+
 
         // 기타 공통
         private final int code;

--- a/src/main/java/com/goormthon/backend/firstsori/global/config/OAuth2ClientConfig.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/config/OAuth2ClientConfig.java
@@ -1,0 +1,33 @@
+package com.goormthon.backend.firstsori.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+
+@Configuration
+public class OAuth2ClientConfig {
+
+    @Bean
+    public OAuth2AuthorizedClientManager authorizedClientManager(
+            ClientRegistrationRepository clientRegistrationRepository,
+            OAuth2AuthorizedClientRepository authorizedClientRepository) {
+
+        OAuth2AuthorizedClientProvider authorizedClientProvider =
+                OAuth2AuthorizedClientProviderBuilder.builder()
+                        .clientCredentials() // client_credentials 플로우 지원
+                        .build();
+
+        DefaultOAuth2AuthorizedClientManager authorizedClientManager =
+                new DefaultOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientRepository);
+        authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
+
+        return authorizedClientManager;
+    }
+}
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/global/config/RedisConfig.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/config/RedisConfig.java
@@ -23,6 +23,8 @@ import java.time.Duration;
 @Configuration
 public class RedisConfig {
     // LettuceConnectionFactory 빈을 생성합니다. 이 팩토리는 Redis 서버와의 연결을 관리합니다.
+    // 현재 세팅 시 lettuce로 구현 시 에러 발생해 현재는 jedis로 구현
+    // 추후 다시 lettuce 기반으로 리팩터링 예정으로 lettuce 부분은 주석처리해놓았습니다.
 
     @Value("${spring.data.redis.host}")
     private String redisHost;
@@ -44,9 +46,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(jedisConnectionFactory());
+        template.setConnectionFactory(redisConnectionFactory);
         return template;
     }
 

--- a/src/main/java/com/goormthon/backend/firstsori/global/config/RedisConfig.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/config/RedisConfig.java
@@ -33,7 +33,7 @@ public class RedisConfig {
     private int redisPort;
 
     @Value("${spring.data.redis.password}")
-    private int redisPassword;
+    private String redisPassword;
 
 
     @Bean

--- a/src/main/java/com/goormthon/backend/firstsori/global/spotify/application/dto/response/SpotifySearchApiResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/spotify/application/dto/response/SpotifySearchApiResponse.java
@@ -1,0 +1,48 @@
+package com.goormthon.backend.firstsori.global.spotify.application.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SpotifySearchApiResponse {
+    private Tracks tracks;
+
+    @Data
+    public static class Tracks {
+        private List<Item> items;
+    }
+
+    @Data
+    public static class Item {
+        private String id;
+        private String name;
+        private List<Artist> artists;
+        private ExternalUrls external_urls;
+        private String preview_url;
+        private Album album;
+    }
+
+    @Data
+    public static class Album {
+        private List<Image> images;
+    }
+
+    @Data
+    public static class Image {
+        private String url;
+        private Integer width;
+        private Integer height;
+    }
+
+    @Data
+    public static class Artist {
+        private String name;
+    }
+
+    @Data
+    public static class ExternalUrls {
+        private String spotify;
+    }
+}
+

--- a/src/main/java/com/goormthon/backend/firstsori/global/spotify/domain/client/SpotifyApiClient.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/spotify/domain/client/SpotifyApiClient.java
@@ -1,0 +1,45 @@
+package com.goormthon.backend.firstsori.global.spotify.domain.client;
+
+import com.goormthon.backend.firstsori.global.spotify.application.dto.response.SpotifySearchApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class SpotifyApiClient {
+
+    private final OAuth2AuthorizedClientManager authorizedClientManager;
+    private final WebClient webClient = WebClient.builder().baseUrl("https://api.spotify.com/v1").build();
+
+
+    public SpotifySearchApiResponse searchMusicRaw(String keyword) {
+        OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest
+                .withClientRegistrationId("spotify")
+                .principal("spotify-client") // 임의의 principal
+                .build();
+
+        OAuth2AuthorizedClient authorizedClient =
+                authorizedClientManager.authorize(authorizeRequest);
+
+        String accessToken = authorizedClient.getAccessToken().getTokenValue();
+
+        // Spotify API 호출 + 응답 DTO 매핑
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/search")
+                        .queryParam("q", keyword)
+                        .queryParam("type", "track")
+                        .queryParam("limit", 40)
+                        .build())
+                .headers(h -> h.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(SpotifySearchApiResponse.class)
+                .block();
+
+    }
+}
+


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- Spotify api 연동 완료
- 곡 검색 api 구현 완료
- API 호출 부하 방지 및 최적화 목적으로 Redis 사용해 검색결과 캐싱 구현

| 구분                     | Key        | Value         | TTL                        |
|--------------------------|-----------|---------------|----------------------------|
| 검색 결과 (키워드 기준)   | 검색 키워드 | 검색 결과     | 일반: 1시간 / 인기 키워드: 24시간 |
| 검색어 검색 횟수          | 검색 키워드 | 검색 횟수     | 7일                        |
| 곡 메타데이터             | 곡 ID      | 곡 메타데이터 | 24시간                     |

- 노션 Secret 페이지에 yml 업데이트
- 유지보수 및 관리 용이를 목적으로 RedisConfig 내 기존의 redisTemplate를 RedisConnectionFactory를 의존성 주입(DI)받는 형태로 리팩터링

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
RedisConfig 수정사항 확인 바랍니다!
- Redis비밀번호 타입 : int -> String
- 기존의 redisTemplate() -> redisTemplate(RedisConnectionFactory redisConnectionFactory) 형태로 리팩터링


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="762" height="434" alt="image" src="https://github.com/user-attachments/assets/7117d571-b3ab-4ea1-b626-908a648c383c" />

<img width="975" height="609" alt="image" src="https://github.com/user-attachments/assets/ecc439a7-939d-4608-8358-691aea2f841d" />


## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
#13 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
