### PR TITLE
[feat/#22] 보드 생성 api, 보드 share_url 조회 api 구현

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/request/CreateBoardRequest.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/request/CreateBoardRequest.java
@@ -1,0 +1,15 @@
+package com.goormthon.backend.firstsori.domain.board.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateBoardRequest {
+
+    private String nickname;
+}
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/CreateBoardResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/CreateBoardResponse.java
@@ -1,0 +1,19 @@
+package com.goormthon.backend.firstsori.domain.board.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CreateBoardResponse {
+    private UUID boardId;
+    private UUID userId;
+    private String nickname;
+    private String shareUri;
+}
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/GetShareUriResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/GetShareUriResponse.java
@@ -1,0 +1,17 @@
+package com.goormthon.backend.firstsori.domain.board.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetShareUriResponse {
+    private UUID boardId;
+    private String shareUri;
+}
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.firstsori.domain.board.application.usecase;
+
+import com.goormthon.backend.firstsori.domain.board.application.dto.request.CreateBoardRequest;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse;
+
+public interface BoardUseCase {
+
+    CreateBoardResponse createBoard(CreateBoardRequest request, String bearerToken);
+
+    GetShareUriResponse getShareUriByUser(String bearerToken);
+}
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
@@ -1,0 +1,114 @@
+package com.goormthon.backend.firstsori.domain.board.application.usecase;
+
+import com.goormthon.backend.firstsori.domain.board.application.dto.request.CreateBoardRequest;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse;
+import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
+import com.goormthon.backend.firstsori.domain.board.domain.repository.BoardRepository;
+import com.goormthon.backend.firstsori.domain.user.application.usecase.UserUseCase;
+import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
+import com.goormthon.backend.firstsori.global.auth.jwt.util.JwtTokenExtractor;
+import com.goormthon.backend.firstsori.global.common.exception.ErrorCode;
+import com.goormthon.backend.firstsori.global.common.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BoardUseCaseImpl implements BoardUseCase {
+
+    private final BoardRepository boardRepository;
+    private final UserUseCase userUseCase;
+    private final JwtTokenExtractor jwtTokenExtractor;
+
+    @Transactional
+    @Override
+    public CreateBoardResponse createBoard(CreateBoardRequest request, String bearerToken) {
+
+        String nickname = request.getNickname();
+        String token = extractTokenFromBearer(bearerToken);
+
+        if (nickname == null || nickname.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+        if (token == null || token.isBlank()) {
+            throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        if (!jwtTokenExtractor.validateToken(token)) {
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+
+        UUID userId = UUID.fromString(jwtTokenExtractor.getId(token));
+        User user = userUseCase.findByUserId(userId);
+
+        boardRepository.findByUser(user).ifPresent(b -> { throw new CustomException(ErrorCode.BAD_REQUEST); });
+
+        // 공유 URI 중복만 방지 (닉네임은 중복 허용)
+        String shareUri = generateUniqueShareUri();
+
+        Board board = Board.builder()
+                .user(user)
+                .nickname(nickname)
+                .shareUri(shareUri)
+                .build();
+
+        Board saved = boardRepository.save(board);
+
+        return CreateBoardResponse.builder()
+                .boardId(saved.getBoardId())
+                .userId(saved.getUser().getUserId())
+                .nickname(saved.getNickname())
+                .shareUri(saved.getShareUri())
+                .build();
+    }
+
+    private String generateUniqueShareUri() {
+        String candidate;
+        do {
+            candidate = RandomStringUtils.randomAlphanumeric(12);
+        } while (boardRepository.existsByShareUri(candidate));
+        return candidate;
+    }
+
+    private String extractTokenFromBearer(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            return null;
+        }
+        if (authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return authorizationHeader;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public GetShareUriResponse getShareUriByUser(String bearerToken) {
+        String token = extractTokenFromBearer(bearerToken);
+
+        if (token == null || token.isBlank()) {
+            throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        if (!jwtTokenExtractor.validateToken(token)) {
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+
+        UUID userId = UUID.fromString(jwtTokenExtractor.getId(token));
+        User user = userUseCase.findByUserId(userId);
+
+        Board board = boardRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+        return GetShareUriResponse.builder()
+                .boardId(board.getBoardId())
+                .shareUri(board.getShareUri())
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
@@ -29,4 +29,10 @@ import java.util.UUID;
 
      @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
      private List<Message> messages = new ArrayList<>();
+
+     @Column(name="nickname", nullable = false)
+     private String nickname;
+
+     @Column(name = "share_uri", nullable = false, unique = true, length = 12)
+     private String shareUri;
  }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/repository/BoardRepository.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/repository/BoardRepository.java
@@ -1,9 +1,17 @@
 package com.goormthon.backend.firstsori.domain.board.domain.repository;
 
 import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
+import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @Repository
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, UUID> {
+
+    Optional<Board> findByUser(User user);
+
+    boolean existsByShareUri(String shareUri);
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
@@ -1,14 +1,16 @@
 package com.goormthon.backend.firstsori.domain.board.presentation;
 
+import com.goormthon.backend.firstsori.domain.board.application.dto.request.CreateBoardRequest;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse;
+import com.goormthon.backend.firstsori.domain.board.application.usecase.BoardUseCase;
 import com.goormthon.backend.firstsori.domain.board.presentation.spec.BoardControllerSpec;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.domain.message.application.usecase.MessageUseCase;
-import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
 import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +22,7 @@ import java.util.UUID;
 public class BoardController implements BoardControllerSpec {
 
     private final MessageUseCase messageUseCase;
+    private final BoardUseCase boardUseCase;
 
     // 개별 메세지 조회
     @GetMapping("/{messageId}")
@@ -35,6 +38,25 @@ public class BoardController implements BoardControllerSpec {
             Pageable pageable) {
         PageResponse<MessageListResponse> messageListResponses = messageUseCase.getMessages(userId, pageable);
         return ApiResponse.ok(messageListResponses);
+    }
+
+    // 보드 생성
+    @PostMapping("/create")
+    public ApiResponse<CreateBoardResponse> createBoard(
+            @RequestBody CreateBoardRequest request,
+            @RequestHeader(value = "Authorization", required = false) String authorization
+    ) {
+        CreateBoardResponse response = boardUseCase.createBoard(request, authorization);
+        return ApiResponse.ok(response);
+    }
+
+    // 보드 공유 URI 조회
+    @GetMapping("/share")
+    public ApiResponse<GetShareUriResponse> getShareUri(
+            @RequestHeader(value = "Authorization", required = false) String authorization
+    ) {
+        GetShareUriResponse response = boardUseCase.getShareUriByUser(authorization);
+        return ApiResponse.ok(response);
     }
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
@@ -3,6 +3,7 @@ package com.goormthon.backend.firstsori.domain.board.presentation.spec;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -11,6 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.UUID;
 
@@ -19,9 +24,14 @@ public interface BoardControllerSpec {
 
     @Operation(summary = "메세지 상세 정보 조회", description = "단일 메세지의 상세 내용을 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
                     content = @io.swagger.v3.oas.annotations.media.Content(
-                            mediaType = "application/json")),
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse.class)
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "메세지 ID를 찾을 수 없음")
     })
     @GetMapping("/{messageId}")
@@ -39,10 +49,7 @@ public interface BoardControllerSpec {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "OK",
-                    content = @io.swagger.v3.oas.annotations.media.Content(
-                            mediaType = "application/json"
-                    )
+                    description = "OK"
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
@@ -62,6 +69,65 @@ public interface BoardControllerSpec {
                     example = "{ \"page\": 0, \"size\": 10, \"sort\": [\"createdDate,desc\"] }"
             )
             Pageable pageable
+    );
+
+    @Operation(
+            summary = "보드 생성",
+            description = "닉네임과 Authorization 헤더의 JWT 토큰으로 보드를 생성합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "Created",
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 입력 또는 이미 존재하는 보드/닉네임"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "토큰이 없거나 유효하지 않음"
+            )
+    })
+    @PostMapping("/create")
+    com.goormthon.backend.firstsori.global.common.response.ApiResponse<com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse> createBoard(
+            @Parameter(description = "생성할 보드 닉네임", example = "나의보드")
+            @RequestBody com.goormthon.backend.firstsori.domain.board.application.dto.request.CreateBoardRequest request,
+
+            @Parameter(description = "인증 토큰이 담긴 Authorization 헤더. 예: Bearer eyJ...")
+            @RequestHeader(value = "Authorization", required = false) String authorization
+    );
+
+    @Operation(
+            summary = "보드 공유 URI 조회",
+            description = "JWT 토큰으로 인증된 사용자의 보드 공유 URI를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "토큰이 없거나 유효하지 않음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "보드를 찾을 수 없음"
+            )
+    })
+    @GetMapping("/share")
+    com.goormthon.backend.firstsori.global.common.response.ApiResponse<GetShareUriResponse> getShareUri(
+            @Parameter(description = "인증 토큰이 담긴 Authorization 헤더. 예: Bearer eyJ...")
+            @RequestHeader(value = "Authorization", required = false) String authorization
     );
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/user/presentation/AuthController.java
@@ -25,16 +25,16 @@ public class AuthController implements AuthControllerSpec {
     private final JwtTokenUseCase tokenService;
 
     @PostMapping("/reissue")
-    public ApiResponse<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<String> reissue(HttpServletRequest request, HttpServletResponse response) {
 
         /// 재발급 하기
         tokenService.reissueByRefreshToken(request, response);
 
-        return ApiResponse.created();
+        return ApiResponse.ok("재발급 완료");
     }
 
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(@AuthenticationPrincipal PrincipalDetails principalDetails, HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<String> logout(@AuthenticationPrincipal PrincipalDetails principalDetails, HttpServletRequest request, HttpServletResponse response) {
 
         // 유저
         UUID userId = principalDetails.getUser().getUserId();
@@ -42,6 +42,6 @@ public class AuthController implements AuthControllerSpec {
         // 리프레쉬 토큰 삭제하기
         tokenService.logout(userId, request, response);
 
-        return ApiResponse.deleted();
+        return ApiResponse.ok("로그아웃 완료");
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/user/presentation/spec/AuthControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/user/presentation/spec/AuthControllerSpec.java
@@ -4,6 +4,7 @@ import com.goormthon.backend.firstsori.global.auth.oauth2.domain.PrincipalDetail
 import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,7 +17,17 @@ public interface AuthControllerSpec {
             summary = "토큰 재발급 API",
             description = "RefeshToken을 바탕으로 AccessToken을 재발급 할 수 있습니다."
     )
-    ApiResponse<Void> reissue(
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = java.lang.String.class)
+                    )
+            )
+    })
+    ApiResponse<String> reissue(
             HttpServletRequest request,
             HttpServletResponse response);
 
@@ -24,7 +35,17 @@ public interface AuthControllerSpec {
             summary = "로그아웃 API",
             description = "쿠키가 존재하고, 카카오/구글을 통해 로그인한 회원에서 가능합니다."
     )
-    ApiResponse<Void> logout(
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = java.lang.String.class)
+                    )
+            )
+    })
+    ApiResponse<String> logout(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             HttpServletRequest request,
             HttpServletResponse response);

--- a/src/main/java/com/goormthon/backend/firstsori/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/common/exception/GlobalExceptionHandler.java
@@ -23,8 +23,9 @@ import java.util.NoSuchElementException;
 public class GlobalExceptionHandler {
 
     /// 공통 처리 메서드
-    private ApiResponse<CustomException> handleCustomException(CustomException customException) {
-        return ApiResponse.fail(customException);
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<CustomException> handleCustomException(CustomException e) {
+        return ApiResponse.fail(e); 
     }
 
     /// 예외 처리


### PR DESCRIPTION
## 📌 작업한 내용  
- 사용자의 jwt 토큰 값으로 보드 + 랜덤 share_url 생성 api
- 사용자의 jwt 토큰 값으로 사용자 소유의 보드 share_url 조회 api


## 🔍 참고 사항  
board 엔티티 수정 -> nickname과 share_url 필드가 새로 생성되었습니다. 

## 🖼️ 스크린샷  
<img width="1170" height="213" alt="image" src="https://github.com/user-attachments/assets/78b999c9-e93b-4efe-820c-a4498822be00" />
보드 생성 성공

<img width="1168" height="179" alt="image" src="https://github.com/user-attachments/assets/aacd9eb5-f9bd-4a7b-8ad0-0e4a7119ec95" />
share_url 조회 성공

## 🔗 관련 이슈  
#22 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
