### PR TITLE
[feat/#24] 인기차트 API 구현

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/MusicChartResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/dto/response/MusicChartResponse.java
@@ -1,0 +1,33 @@
+package com.goormthon.backend.firstsori.domain.music.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Builder
+@Getter
+@Setter
+@Schema(name = "MusicChartResponse", description = "음악 인기 차트 응답 DTO")
+public class MusicChartResponse {
+
+    @Schema(description = "음악 고유 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    private UUID musicId;
+
+    @Schema(description = "노래 제목", example = "Shape of You")
+    private String songName;
+
+    @Schema(description = "가수 이름", example = "Ed Sheeran")
+    private String artist;
+
+    @Schema(description = "앨범 이미지 URL", example = "https://example.com/album/image.jpg")
+    private String albumImageUrl;
+
+    @Schema(description = "노래 URL", example = "https://example.com/song/url")
+    private String songUrl;
+
+    @Schema(description = "인기 점수", example = "15.5")
+    private double score;
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/mapper/MusicMapper.java
@@ -1,5 +1,6 @@
 package com.goormthon.backend.firstsori.domain.music.application.mapper;
 
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.MusicChartResponse;
 import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
 
 public class MusicMapper {
@@ -10,6 +11,17 @@ public class MusicMapper {
                 .artist(artist)
                 .albumImageUrl(albumImageUrl)
                 .songUrl(songUrl)
+                .build();
+    }
+
+    public static MusicChartResponse toMusicChartResponse(Music music,double score) {
+        return MusicChartResponse.builder()
+                .musicId(music.getMusicId())
+                .songName(music.getSongName())
+                .artist(music.getArtist())
+                .albumImageUrl(music.getAlbumImageUrl())
+                .songUrl(music.getSongUrl())
+                .score(score)
                 .build();
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCase.java
@@ -1,9 +1,14 @@
 package com.goormthon.backend.firstsori.domain.music.application.usecase;
 
 import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.MusicChartResponse;
+
+import java.util.List;
 
 public interface MusicUseCase {
 
     GetSearchResultResponse getSearchResult(String keyword);
+
+    List<MusicChartResponse> getPopularMusic(int topN);
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/application/usecase/MusicUseCaseImpl.java
@@ -1,11 +1,16 @@
 package com.goormthon.backend.firstsori.domain.music.application.usecase;
 
 import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.MusicChartResponse;
 import com.goormthon.backend.firstsori.domain.music.domain.service.GetMusicSearchResultService;
+import com.goormthon.backend.firstsori.domain.music.domain.service.GetPopularMusicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -14,9 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class MusicUseCaseImpl implements MusicUseCase {
 
     private final GetMusicSearchResultService getMusicSearchResultService;
+    private final GetPopularMusicService getMusicChartService;
+
 
     @Override
     public GetSearchResultResponse getSearchResult(String keyword) {
         return new GetSearchResultResponse(getMusicSearchResultService.getSearchResult(keyword));
+    }
+
+    @Override
+    public List<MusicChartResponse> getPopularMusic(int topN) {
+        return getMusicChartService.getPopularMusic(topN);
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/repository/MusicRepository.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/repository/MusicRepository.java
@@ -4,7 +4,10 @@ import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MusicRepository extends JpaRepository<Music, Long> {
 
+    List<Music> findBySongName(String songName);
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/GetPopularMusicService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/GetPopularMusicService.java
@@ -1,0 +1,66 @@
+package com.goormthon.backend.firstsori.domain.music.domain.service;
+
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.MusicChartResponse;
+import com.goormthon.backend.firstsori.domain.music.application.mapper.MusicMapper;
+import com.goormthon.backend.firstsori.domain.music.domain.entity.Music;
+import com.goormthon.backend.firstsori.domain.music.domain.repository.MusicRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class GetPopularMusicService {
+
+
+    private static final String POPULAR_MUSIC_KEY = "chart:popular_music_sorted_set";
+
+    private final StringRedisTemplate redisTemplate;
+    private final MusicRepository musicRepository;
+
+    /**
+     * 인기 차트 상위 N개 곡 조회
+     */
+    public List<MusicChartResponse> getPopularMusic(int topN) {
+        Set<ZSetOperations.TypedTuple<String>> topMusic = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(POPULAR_MUSIC_KEY, 0, -1);   // ZSet에서 점수가 높은 순으로 모든 곡과 점수 조회
+
+        if (topMusic == null || topMusic.isEmpty()) return Collections.emptyList();
+
+        Map<String, MusicChartResponse> chartMap = new HashMap<>();
+        for (ZSetOperations.TypedTuple<String> tuple : topMusic) {
+            String songName = tuple.getValue();
+            if (songName == null || songName.isBlank()) continue;
+
+            List<Music> musicList = musicRepository.findBySongName(songName);  // DB에서 songName으로 음악 정보 리스트 조회
+            if (!musicList.isEmpty()) {
+
+                // 각 음악을 응답 객체로 변환 후 맵에 저장, 이미 있으면 점수(score)를 누적
+                for (Music music : musicList) {
+                    chartMap.compute(songName, (k, existing) -> {
+                        if (existing == null) {
+                            return MusicMapper.toMusicChartResponse(music, 1); // 1점씩 시작
+                        } else {
+                            existing.setScore(existing.getScore() + 1); // 1점씩 누적
+                            return existing;
+                        }
+                    });
+                }
+            }
+        }
+
+        // 점수 내림차순으로 정렬 후 상위 topN 개만 리스트로 반환
+        return chartMap.values().stream()
+                .sorted((a, b) -> Double.compare(b.getScore(), a.getScore()))
+                .limit(topN)
+                .toList();
+    }
+
+
+}
+
+
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/MusicEventConsumer.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/MusicEventConsumer.java
@@ -1,0 +1,57 @@
+package com.goormthon.backend.firstsori.domain.music.domain.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MusicEventConsumer {
+
+    private static final String MUSIC_EVENT_STREAM = "chart:music_event_stream";
+    private static final String POPULAR_MUSIC_KEY = "chart:popular_music_sorted_set";
+
+    private static final String GROUP_NAME = "music_event_group"; // 메세지를 처리하는 소비자 그룹 이름
+    private static final String CONSUMER_NAME = "consumer_1"; // 그룹 내 comsumer를 구분하는 id (추후에 확장할 예정)
+    private final StringRedisTemplate redisTemplate;
+
+    @PostConstruct
+    public void initGroup() {
+        try {
+            redisTemplate.opsForStream().createGroup(MUSIC_EVENT_STREAM, GROUP_NAME);
+        } catch (Exception e) {
+            // 그룹이 이미 존재하면 예외 발생할 수 있어 무시 가능
+        }
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void consume() {
+        List<MapRecord<String, Object, Object>> messages = redisTemplate.opsForStream().read(
+                Consumer.from(GROUP_NAME, CONSUMER_NAME),
+                org.springframework.data.redis.connection.stream.StreamReadOptions.empty().count(10).block(Duration.ofSeconds(1)),
+                StreamOffset.create(MUSIC_EVENT_STREAM, org.springframework.data.redis.connection.stream.ReadOffset.lastConsumed())
+        );
+
+        if (messages == null || messages.isEmpty()) return;
+
+        for (MapRecord<String, Object, Object> message : messages) {
+            try {
+                String songName = (String) message.getValue().get("songName");
+
+                redisTemplate.opsForZSet().incrementScore(POPULAR_MUSIC_KEY, songName, 1);  // ZSet에 musicId 점수 증
+
+                redisTemplate.opsForStream().acknowledge(MUSIC_EVENT_STREAM, GROUP_NAME, message.getId());  // 스트림 메시지 ack
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/MusicEventProducer.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/MusicEventProducer.java
@@ -1,0 +1,27 @@
+package com.goormthon.backend.firstsori.domain.music.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MusicEventProducer {
+
+    private static final String MUSIC_EVENT_STREAM = "chart:music_event_stream";
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 곡 선택 시 이벤트 발행
+     */
+    public void publishMusicEvent(String songName) {
+        Map<String, String> event = Map.of(
+                "songName", String.valueOf(songName),
+                "timestamp", String.valueOf(System.currentTimeMillis())
+        );
+        redisTemplate.opsForStream().add(MUSIC_EVENT_STREAM, event);
+    }
+
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/SaveMusicService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/domain/service/SaveMusicService.java
@@ -12,8 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class SaveMusicService {
 
     private final MusicRepository musicRepository;
+    private final MusicEventProducer musicEventProducer;
 
     public void saveMusic(Music music) {
-        musicRepository.save(music);
+        // DB에 음악 저장
+        Music savedMusic = musicRepository.save(music);
+        // 인기 차트 이벤트 발행
+        musicEventProducer.publishMusicEvent(savedMusic.getSongName());
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/MusicController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/MusicController.java
@@ -1,6 +1,7 @@
 package com.goormthon.backend.firstsori.domain.music.presentation;
 
 import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.MusicChartResponse;
 import com.goormthon.backend.firstsori.domain.music.application.usecase.MusicUseCase;
 import com.goormthon.backend.firstsori.domain.music.presentation.spec.MusicControllerSpec;
 import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Slf4j
 @RequestMapping("/api/v1/music")
@@ -26,4 +29,12 @@ public class MusicController implements MusicControllerSpec {
         GetSearchResultResponse response = musicUseCase.getSearchResult(keyword);
         return ApiResponse.ok(response);
     }
+
+    // 음악 인기 차트
+    @GetMapping("/popular-chart")
+    public ApiResponse<List<MusicChartResponse>> getPopularMusic(@RequestParam(defaultValue = "10") int topN){
+        List<MusicChartResponse> responses= musicUseCase.getPopularMusic(topN);
+         return ApiResponse.ok(responses);
+    }
+
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/spec/MusicControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/music/presentation/spec/MusicControllerSpec.java
@@ -1,10 +1,14 @@
 package com.goormthon.backend.firstsori.domain.music.presentation.spec;
 
 import com.goormthon.backend.firstsori.domain.music.application.dto.response.GetSearchResultResponse;
+import com.goormthon.backend.firstsori.domain.music.application.dto.response.MusicChartResponse;
 import com.goormthon.backend.firstsori.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "음악 관련 API", description = "음악 검색 기능을 제공하는 API 입니다.")
 public interface MusicControllerSpec {
@@ -15,5 +19,12 @@ public interface MusicControllerSpec {
     )
     ApiResponse<GetSearchResultResponse> getSearchResult(
             @RequestParam String keyword);
+
+    @Operation(
+            summary = "인기 음악 차트 조회 API",
+            description = "저장이 많이 된 음악을 내림차순으로 10개 반환합니다."
+    )
+    @GetMapping("/popular-chart")
+    ApiResponse<List<MusicChartResponse>> getPopularMusic(@RequestParam(defaultValue = "10") int topN);
 }
 

--- a/src/main/java/com/goormthon/backend/firstsori/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/common/exception/ErrorCode.java
@@ -61,8 +61,8 @@ public enum ErrorCode {
         NOT_FOUND_END_POINT(404_000, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
         USER_NOT_FOUND(404_001, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
         USER_NOT_FOUND_IN_COOKIE(404_002, HttpStatus.NOT_FOUND, "쿠키에서 사용자 정보를 찾을 수 없습니다."),
-        MESSAGE_NOT_FOUND(400_003, HttpStatus.NOT_FOUND, "메시지를 찾을 수 없습니다."),
-        BOARD_NOT_FOUND(400_004, HttpStatus.NOT_FOUND, "유저의 보드를 찾을 수 없습니다."),
+        MESSAGE_NOT_FOUND(404_003, HttpStatus.NOT_FOUND, "메시지를 찾을 수 없습니다."),
+        BOARD_NOT_FOUND(404_004, HttpStatus.NOT_FOUND, "유저의 보드를 찾을 수 없습니다."),
                 
         // ========================
         // 409 Conflict


### PR DESCRIPTION
## 📌 작업한 내용  
- Redis Sorted Set과 Stream을 활용한 인기 음악 차트 기능 개발

- Redis Stream Consumer 그룹 및 Consumer 네임 지정으로 안정적 메시지 처리 구조 적용

- 점수 내림차 순으로 정렬 후 상위 10개 리스트로 반환
- Redis 인기 음악 ZSet에서 점수 내림차순 조회 후 DB에서 곡 메타 정보 조회하여 결과 반환

- 여러 곡 이름에 대응하는 다중 결과 처리 로직 보완
 
## 🔍 참고 사항  


## 🖼️ 스크린샷  
- 인기 음악 차트 조회 API
<img width="1151" height="890" alt="image" src="https://github.com/user-attachments/assets/a6dd45aa-a594-468a-b3ce-dcc534d187ca" />

## 🔗 관련 이슈  
#24 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
