### PR TITLE
[feature/#43] 프로필 정보 수정

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/request/UpdateBoardRequest.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/request/UpdateBoardRequest.java
@@ -1,0 +1,14 @@
+package com.goormthon.backend.firstsori.domain.board.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateBoardRequest {
+
+    private String nickname;
+    private String profileImage;
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/UpdateBoardResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/UpdateBoardResponse.java
@@ -1,0 +1,18 @@
+package com.goormthon.backend.firstsori.domain.board.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UpdateBoardResponse {
+    private UUID boardId;
+    private UUID userId;
+    private String nickname;
+    private String profileImage;
+    private String shareUri;
+}

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
@@ -1,9 +1,11 @@
 package com.goormthon.backend.firstsori.domain.board.application.usecase;
 
 import com.goormthon.backend.firstsori.domain.board.application.dto.request.CreateBoardRequest;
+import com.goormthon.backend.firstsori.domain.board.application.dto.request.UpdateBoardRequest;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardInfoResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.UpdateBoardResponse;
 import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
 
 import java.util.UUID;
@@ -15,5 +17,7 @@ public interface BoardUseCase {
     GetShareUriResponse getShareUriByUser(User user);
 
     BoardInfoResponse getBoardInfo(UUID userId);
+
+    UpdateBoardResponse updateBoard(UpdateBoardRequest request, User user);
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
@@ -49,5 +49,8 @@ import java.util.UUID;
          }
      }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 
  }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
@@ -2,9 +2,11 @@ package com.goormthon.backend.firstsori.domain.board.presentation;
 
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardInfoResponse;
 import com.goormthon.backend.firstsori.domain.board.application.dto.request.CreateBoardRequest;
+import com.goormthon.backend.firstsori.domain.board.application.dto.request.UpdateBoardRequest;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardPreviewResponse;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.CreateBoardResponse;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.GetShareUriResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.UpdateBoardResponse;
 import com.goormthon.backend.firstsori.domain.board.application.usecase.BoardUseCase;
 import com.goormthon.backend.firstsori.domain.board.presentation.spec.BoardControllerSpec;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
@@ -77,6 +79,16 @@ public class BoardController implements BoardControllerSpec {
     public ApiResponse<BoardInfoResponse> getBoardInfo(@AuthenticationPrincipal PrincipalDetails user) {
         BoardInfoResponse boardInfo=boardUseCase.getBoardInfo(user.getId());
         return ApiResponse.ok(boardInfo);
+    }
+
+    // 보드 수정 (닉네임, 프로필 이미지)
+    @PatchMapping("/update")
+    public ApiResponse<UpdateBoardResponse> updateBoard(
+            @RequestBody UpdateBoardRequest request,
+            @AuthenticationPrincipal PrincipalDetails user
+    ) {
+        UpdateBoardResponse response = boardUseCase.updateBoard(request, user.getUser());
+        return ApiResponse.ok(response);
     }
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
@@ -169,11 +169,11 @@ public interface BoardControllerSpec {
     );
 
     @Operation(
-            summary = "보드 수정",
+            summary = "프로필 수정",
             description = "JWT 토큰으로 인증된 사용자의 보드 닉네임과 프로필 이미지를 수정합니다."
     )
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "보드 수정 성공",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 수정 성공",
                     content = @io.swagger.v3.oas.annotations.media.Content(
                             mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
@@ -1,6 +1,8 @@
 package com.goormthon.backend.firstsori.domain.board.presentation.spec;
 
+import com.goormthon.backend.firstsori.domain.board.application.dto.request.UpdateBoardRequest;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardInfoResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.UpdateBoardResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
 import com.goormthon.backend.firstsori.global.auth.oauth2.domain.PrincipalDetails;
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -165,5 +168,26 @@ public interface BoardControllerSpec {
             @PathVariable String shareUri
     );
 
+    @Operation(
+            summary = "보드 수정",
+            description = "JWT 토큰으로 인증된 사용자의 보드 닉네임과 프로필 이미지를 수정합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "보드 수정 성공",
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = com.goormthon.backend.firstsori.domain.board.application.dto.response.UpdateBoardResponse.class
+                            )
+                    )),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 입력"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (토큰 부재 또는 유효하지 않은 토큰)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "보드를 찾을 수 없음")
+    })
+    @PatchMapping("/update")
+    com.goormthon.backend.firstsori.global.common.response.ApiResponse<UpdateBoardResponse> updateBoard(
+            @RequestBody UpdateBoardRequest request,
+            @AuthenticationPrincipal PrincipalDetails user
+    );
 
 }


### PR DESCRIPTION
## 📌 작업한 내용  
프로필 정보 수정하는 patch api 구현

## 🔍 참고 사항  


## 🖼️ 스크린샷  
<img width="883" height="268" alt="image" src="https://github.com/user-attachments/assets/3839193c-d40c-42b1-9c61-0f9fa5a310ea" />
<img width="883" height="243" alt="image" src="https://github.com/user-attachments/assets/ee093ab8-2b01-4e07-81b2-87a780150af4" />
<img width="1253" height="56" alt="image" src="https://github.com/user-attachments/assets/5b72861e-48de-423e-adb2-00dd4b5852c6" />

보드 정보 조회 api에서 name이 user name으로 반환하여 여기는 반영이 안된 것 처럼 보이지만 db에서 보드 테이블의 nickname이 바뀐 것을 볼 수 있습니다


## 🔗 관련 이슈  
#43 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
