### PR TITLE
[hotfix/#44] 보드 정보 조회 API 수정

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/BoardInfoResponse.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/dto/response/BoardInfoResponse.java
@@ -3,6 +3,8 @@ package com.goormthon.backend.firstsori.domain.board.application.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 // 보드 정보 응답 DTO
 @Builder
 @Schema(description = "보드 정보 및 소유자 프로필 응답")
@@ -14,5 +16,11 @@ public record BoardInfoResponse(
         String profileImage,
 
         @Schema(description = "보드에 등록된 메시지 수")
-        Integer messageCount) {
+        Integer messageCount,
+
+        @Schema(description="서버 시간")
+        LocalDateTime serverTime
+
+) {
 }
+

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/mapper/BoardMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/mapper/BoardMapper.java
@@ -2,6 +2,8 @@ package com.goormthon.backend.firstsori.domain.board.application.mapper;
 
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardInfoResponse;
 
+import java.time.LocalDateTime;
+
 public class BoardMapper {
 
     public static BoardInfoResponse toBoardInfoResponse(String name,String profileImage,Integer messageCount) {
@@ -9,6 +11,7 @@ public class BoardMapper {
                 .name(name)
                 .profileImage(profileImage)
                 .messageCount(messageCount)
+                .serverTime(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCase.java
@@ -14,6 +14,6 @@ public interface BoardUseCase {
 
     GetShareUriResponse getShareUriByUser(User user);
 
-    BoardInfoResponse getBoardInfo(UUID userId);
+    BoardInfoResponse getBoardInfo(String shareUri);
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
@@ -7,6 +7,7 @@ import com.goormthon.backend.firstsori.domain.board.application.dto.response.Boa
 import com.goormthon.backend.firstsori.domain.board.application.mapper.BoardMapper;
 import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
 import com.goormthon.backend.firstsori.domain.board.domain.repository.BoardRepository;
+import com.goormthon.backend.firstsori.domain.board.domain.service.GetBoardService;
 import com.goormthon.backend.firstsori.domain.user.application.usecase.UserUseCase;
 import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
 import com.goormthon.backend.firstsori.global.auth.jwt.util.JwtTokenExtractor;
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,6 +33,7 @@ public class BoardUseCaseImpl implements BoardUseCase {
     private final UserUseCase userUseCase;
     private final JwtTokenExtractor jwtTokenExtractor;
     private final GetUserService getUserService;
+    private final GetBoardService getBoardService;
 
     @Transactional
     @Override
@@ -100,13 +103,10 @@ public class BoardUseCaseImpl implements BoardUseCase {
 
     @Transactional(readOnly = true)
     @Override
-    public BoardInfoResponse getBoardInfo(UUID userId) {
-        User user = Optional.ofNullable(getUserService.validateUserExists(userId))
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        // 보드랑 연결후에 작동 (혜연님 코드)
-        Board board = Optional.ofNullable(user.getBoard())
-                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
-        return BoardMapper.toBoardInfoResponse(user.getName(), user.getProfileImage(), board.getMessageCount());
+    public BoardInfoResponse getBoardInfo(String shareUri) {
+        Board board = getBoardService.getBoardBySharedId(shareUri);
+
+        return BoardMapper.toBoardInfoResponse(board.getNickname(), board.getUser().getProfileImage(), board.getMessageCount());
     }
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
@@ -73,9 +73,9 @@ public class BoardController implements BoardControllerSpec {
 
 
     // 보드 정보 반환
-    @GetMapping("/info")
-    public ApiResponse<BoardInfoResponse> getBoardInfo(@AuthenticationPrincipal PrincipalDetails user) {
-        BoardInfoResponse boardInfo=boardUseCase.getBoardInfo(user.getId());
+    @GetMapping("/info/{sharedUri}")
+    public ApiResponse<BoardInfoResponse> getBoardInfo(@PathVariable String sharedUri) {
+        BoardInfoResponse boardInfo=boardUseCase.getBoardInfo(sharedUri);
         return ApiResponse.ok(boardInfo);
     }
 

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
@@ -78,7 +78,7 @@ public interface BoardControllerSpec {
     })
     @GetMapping("/info")
     com.goormthon.backend.firstsori.global.common.response.ApiResponse<BoardInfoResponse> getBoardInfo(
-            @AuthenticationPrincipal PrincipalDetails user
+            @PathVariable String shareUri
     );
 
     @Operation(

--- a/src/main/java/com/goormthon/backend/firstsori/domain/user/domain/service/GetUserService.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/user/domain/service/GetUserService.java
@@ -22,4 +22,5 @@ public class GetUserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
+
 }

--- a/src/main/java/com/goormthon/backend/firstsori/global/common/logging/ControllerLoggingAspect.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/common/logging/ControllerLoggingAspect.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 @Slf4j
 public class ControllerLoggingAspect {
 
-    @Pointcut("execution(* com.goormthon.backend.firstsori..*Controller.*(..))")
+    @Pointcut("execution(* com.goormthon.backend.firstsori..*Controller.*(..)) && !within(com.goormthon.backend.firstsori.domain.music.domain.service.MusicEventConsumer)")
     private void controllerPointcut() {}
 
     @Before("controllerPointcut()")


### PR DESCRIPTION
## 📌 작업한 내용  
- response에서 serverTime 추가
- sharedUri로 조회하도록 변경
- board nickname반환하도록 수정

## 🔍 참고 사항  


## 🖼️ 스크린샷  
<img width="1180" height="1172" alt="image" src="https://github.com/user-attachments/assets/b6d390f1-5bde-492b-85ef-39c21c72b27a" />

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
