### PR TITLE
[hotfix/#48] : 프로필 변경 fix

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/entity/Board.java
@@ -16,6 +16,7 @@ import java.util.UUID;
  @Table(name = "boards")
  @AllArgsConstructor
  @Builder
+ @org.hibernate.annotations.DynamicUpdate
  public class Board extends BaseTimeEntity {
 
      @Id

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/repository/BoardRepository.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/domain/repository/BoardRepository.java
@@ -3,6 +3,9 @@ package com.goormthon.backend.firstsori.domain.board.domain.repository;
 import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
 import com.goormthon.backend.firstsori.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -18,4 +21,12 @@ public interface BoardRepository extends JpaRepository<Board, UUID> {
     Optional<Board> findByUser(User user);
 
     boolean existsByShareUri(String shareUri);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Board b set b.nickname = :nickname where b.user = :user")
+    int updateNicknameByUser(@Param("user") User user, @Param("nickname") String nickname);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Board b set b.messageCount = b.messageCount + :delta where b.boardId = :boardId")
+    int incrementMessageCountById(@Param("boardId") UUID boardId, @Param("delta") int delta);
 }

--- a/src/main/java/com/goormthon/backend/firstsori/global/common/scheduler/BoardCountSyncScheduler.java
+++ b/src/main/java/com/goormthon/backend/firstsori/global/common/scheduler/BoardCountSyncScheduler.java
@@ -35,13 +35,11 @@ public class BoardCountSyncScheduler {
             if (countString != null) {
                 Integer redisCount = Integer.parseInt(countString);
 
-                // DB의 기존 카운트에 Redis 카운트 값을 더함
-                board.incrementMessageCount(redisCount);
-                boardRepository.save(board);
+                // 변경 컬럼만 업데이트(닉네임 등 다른 컬럼을 덮어쓰지 않도록 함)
+                boardRepository.incrementMessageCountById(board.getBoardId(), redisCount);
 
                 // Redis 카운트 초기화
-                redisTemplate.delete(redisKey); //  redisTemplate.opsForValue().set(redisKey, "0");
-//                log.info("Board ID: {}에 {}개의 메시지 카운트 동기화 완료.", board.getBoardId(), redisCount);
+                redisTemplate.delete(redisKey);
             }
         }
 //        log.info("[스케줄러 종료] Board 메시지 카운트 동기화 완료.");


### PR DESCRIPTION
## 📌 작업한 내용  
- Board에 DynamicUpdate 적용
- 스케줄러에서 messageCount만 전용 UPDATE 쿼리로 반영
닉네임 업데이트는 강제 UPDATE 쿼리 사용 + 저장 순서 조정(유저 저장→닉네임 업데이트→재조회)


## 🔍 참고 사항  
스케쥴러 관련 코드 수정사항이 있어 꼭 리뷰 부탁드립니다


## 🖼️ 스크린샷  

## 🔗 관련 이슈  
#48 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
