### PR TITLE
[Feat/#52] 보드의 메세지 리스트 조회 api에 페이징 구현

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/BoardController.java
@@ -49,8 +49,10 @@ public class BoardController implements BoardControllerSpec {
 
     // 외부인 접속 시 전체 메세지 앨범 커버만 조회
     @GetMapping("/shared/{shareUri}")
-    public ApiResponse<List<BoardPreviewResponse>> getBoardMessages(@PathVariable String shareUri) {
-        List<BoardPreviewResponse> response = messageUseCase.getMessagesByBoardShareUri(shareUri);
+    public ApiResponse<PageResponse<BoardPreviewResponse>> getMessagesFromNonOwner(
+            @PathVariable String shareUri,
+            Pageable pageable) {
+        PageResponse<BoardPreviewResponse> response = messageUseCase.getMessagesByBoardShareUri(shareUri, pageable);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/presentation/spec/BoardControllerSpec.java
@@ -2,6 +2,7 @@ package com.goormthon.backend.firstsori.domain.board.presentation.spec;
 
 import com.goormthon.backend.firstsori.domain.board.application.dto.request.UpdateBoardRequest;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardInfoResponse;
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardPreviewResponse;
 import com.goormthon.backend.firstsori.domain.board.application.dto.response.UpdateBoardResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageResponse;
@@ -136,8 +137,8 @@ public interface BoardControllerSpec {
             );
 
     @Operation(
-            summary = "외부 사용자 보드 메세지 조회",
-            description = "공유 URI를 통해 외부 사용자가 접근할 때, 해당 보드의 전체 메세지 앨범 커버 정보를 조회합니다."
+            summary = "외부 사용자가 보드 메세지 조회",
+            description = "공유 URI를 통해 외부 사용자가 접근할 때, 해당 보드의 전체 메시지 앨범 커버 정보를 페이지네이션과 함께 조회합니다."
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -145,10 +146,8 @@ public interface BoardControllerSpec {
                     description = "OK",
                     content = @io.swagger.v3.oas.annotations.media.Content(
                             mediaType = "application/json",
-                            array = @io.swagger.v3.oas.annotations.media.ArraySchema(
-                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
-                                            implementation = com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardPreviewResponse.class
-                                    )
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = com.goormthon.backend.firstsori.global.common.response.page.PageResponse.class
                             )
                     )
             ),
@@ -159,13 +158,18 @@ public interface BoardControllerSpec {
     })
     @GetMapping("/shared/{shareUri}")
     com.goormthon.backend.firstsori.global.common.response.ApiResponse<
-            java.util.List<com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardPreviewResponse>
-            > getBoardMessages(
+            PageResponse<BoardPreviewResponse>
+            > getMessagesFromNonOwner(
             @Parameter(
                     description = "공유 URI",
                     example = "a1b2c3d4e5f6"
             )
-            @PathVariable String shareUri
+            @PathVariable String shareUri,
+            @Parameter(
+                    description = "페이지 정보 (page, size, sort)",
+                    example = "{ \"page\": 0, \"size\": 10, \"sort\": [\"desc\"] }"
+            )
+            Pageable pageable
     );
 
     @Operation(

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/mapper/MessageMapper.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/mapper/MessageMapper.java
@@ -1,5 +1,6 @@
 package com.goormthon.backend.firstsori.domain.message.application.mapper;
 
+import com.goormthon.backend.firstsori.domain.board.application.dto.response.BoardPreviewResponse;
 import com.goormthon.backend.firstsori.domain.board.domain.entity.Board;
 import com.goormthon.backend.firstsori.domain.message.application.dto.request.SaveMessageRequest;
 import com.goormthon.backend.firstsori.domain.message.application.dto.response.MessageListResponse;
@@ -79,6 +80,28 @@ public class MessageMapper {
                 .music(music)
                 .read(false)
                 .customImageUrl(null)
+                .build();
+    }
+
+    public static BoardPreviewResponse toBoardPreviewResponse(Message message) {
+        return BoardPreviewResponse.builder()
+                .messageId(message.getMessageId())
+                .musicId(message.getMusic().getMusicId())
+                .musicCoverUrl(message.getMusic().getAlbumImageUrl())
+                .build();
+    }
+
+    public static PageResponse<BoardPreviewResponse> toBoardPreviewPageResponse(Page<Message> messages) {
+        List<BoardPreviewResponse> content = messages.stream()
+                .map(MessageMapper::toBoardPreviewResponse)
+                .collect(Collectors.toList());
+
+        return PageResponse.<BoardPreviewResponse>builder()
+                .content(content)
+                .pageNumber(messages.getNumber())
+                .pageSize(messages.getSize())
+                .totalElements(messages.getTotalElements())
+                .totalPages(messages.getTotalPages())
                 .build();
     }
 

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCase.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCase.java
@@ -7,7 +7,6 @@ import com.goormthon.backend.firstsori.domain.message.application.dto.response.M
 import com.goormthon.backend.firstsori.global.common.response.page.PageResponse;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface MessageUseCase {
@@ -18,6 +17,6 @@ public interface MessageUseCase {
 
     void createMessage(SaveMessageRequest request);
 
-    List<BoardPreviewResponse> getMessagesByBoardShareUri(String shareUri);
+    PageResponse<BoardPreviewResponse> getMessagesByBoardShareUri(String shareUri, Pageable pageable);
 
 }

--- a/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/message/application/usecase/MessageUseCaseImpl.java
@@ -81,16 +81,15 @@ public class MessageUseCaseImpl implements MessageUseCase {
     }
 
     @Transactional(readOnly = true)
-    public List<BoardPreviewResponse> getMessagesByBoardShareUri(String shareUri) {
-        Board board = getBoardService.getBoardBySharedId(shareUri); // Board 조회
+    @Override
+    public PageResponse<BoardPreviewResponse> getMessagesByBoardShareUri(String shareUri, Pageable pageable) {
+        Board board = Optional.ofNullable(getBoardService.getBoardBySharedId(shareUri))
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
 
-        return board.getMessages().stream()
-                .map(message -> BoardPreviewResponse.builder()
-                        .messageId(message.getMessageId())
-                        .musicId(message.getMusic().getMusicId())  // Music ID
-                        .musicCoverUrl(message.getMusic().getAlbumImageUrl())  // Music Cover
-                        .build())
-                .toList();
+
+        Page<Message> messages = getMessageService.getMessageList(board.getUser().getUserId(), pageable);
+
+        return MessageMapper.toBoardPreviewPageResponse(messages);
     }
 
 }


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
sharedId로 타인 보드의 메세지 조회 api에 paging 적용

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 공통 로직 코드는 따로 안건들고 기존 api 메서드 내에서 코드 변경, 또는 메서드 추가해서 구현하여서 따로 공통부분 코드 변경사항은 없습니다
- 기존의 PagingResponse 만 수정 없이 응답 dto로 사용했습니다!
 
## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
-메세지 12개 db에 입력해서 api 호출 시도함
- row clone하고 uuid만 카운팅 올라가게 해놔서 uuid 보시면 각각 다른 row인것 확인가능
- 요청request
<img width="539" height="327" alt="image" src="https://github.com/user-attachments/assets/2a148a07-ae8b-4277-b92a-2ba1fca43d33" />

<img width="566" height="506" alt="image" src="https://github.com/user-attachments/assets/938eb083-19a0-46d7-9ff9-320f04e0568b" />
<img width="547" height="349" alt="image" src="https://github.com/user-attachments/assets/847386a2-5fa9-4b56-b62e-0178c2bc5204" />

- page:1 값으로 재호출시 나머지 정상조회 되는 것 2개 확인
- 갯수 카운트 모두 정상적으로 response 되는 것도 확인 가능
<img width="638" height="550" alt="image" src="https://github.com/user-attachments/assets/eff63889-45a2-4934-9ff1-991c40f265c8" />


## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
#52 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
