### PR TITLE
[hotfix/#56] board share url api 수정

### DIFF
--- a/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
+++ b/src/main/java/com/goormthon/backend/firstsori/domain/board/application/usecase/BoardUseCaseImpl.java
@@ -97,7 +97,14 @@ public class BoardUseCaseImpl implements BoardUseCase {
     public GetShareUriResponse getShareUriByUser(User user) {
 
         Board board = boardRepository.findByUser(user)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+                .orElse(null);
+
+        if (board == null) {
+            return GetShareUriResponse.builder()
+                    .boardId(null)
+                    .shareUri(null)
+                    .build();
+        }
 
         return GetShareUriResponse.builder()
                 .boardId(board.getBoardId())


### PR DESCRIPTION
## 📌 작업한 내용  
보드가 없는 유저가 호출할 경우 404에러가 아닌 null 값 반환하도록 수정

## 🔍 참고 사항  


## 🖼️ 스크린샷  
<img width="883" height="232" alt="image" src="https://github.com/user-attachments/assets/7f87c6b9-91e0-49b1-b1d1-4f8c9a3a0f23" />


## 🔗 관련 이슈  
#56 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
